### PR TITLE
Support SVG image uploads

### DIFF
--- a/db/models/mining-monthly-report.js
+++ b/db/models/mining-monthly-report.js
@@ -225,7 +225,7 @@ module.exports = (sequelize, DataTypes) => {
       (output) =>
         new Promise(async (resolve, reject) => {
           try {
-            console.log('Finding app with BTC Address', output.addresses[0]);
+            console.log('Finding app with BTC Address', output.addr);
             // const [BTCAddress] = output.addresses;
             const BTCAddress = output.addr;
             const app = await MiningMonthlyReport.App.findOne({

--- a/db/models/mining-monthly-report.js
+++ b/db/models/mining-monthly-report.js
@@ -250,7 +250,7 @@ module.exports = (sequelize, DataTypes) => {
               });
               await payment.update({
                 ...paymentAttrs,
-                BTCPaymentValue: output.value * 10e-9,
+                BTCPaymentValue: output.value,
               });
               console.log(payment.dataValues);
               return resolve(payment);


### PR DESCRIPTION
This PR adds support for SVG images, which can close https://github.com/blockstackpbc/app.co-api/issues/1 .

I also added a timeout to the fetching of the image, so that the whole submission request doesn't fail in the case of an image timeout.