### PR TITLE
fix: CSV export of app mining results

### DIFF
--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -253,7 +253,7 @@ router.get('/mining-reports/:monthId/download-rankings', async (req, res) => {
     { ...MiningMonthlyReport.includeOptions[1] },
   ];
   includeOptions[0].include[0].include[0].attributes.exclude = [];
-  const month = await MiningMonthlyReport.findById(req.params.monthId, { include: includeOptions });
+  const month = await MiningMonthlyReport.findByPk(req.params.monthId, { include: includeOptions });
   month.compositeRankings = await month.getCompositeRankings();
   const rankings = month.compositeRankings.map((app) => {
     const appData = {


### PR DESCRIPTION
Reference: https://github.com/blockstack/app.co/issues/632

Was encountering Cloudflare HTTP 524 timeout error. Turns out `findById` isn't a sequalize method. Two letter fix.