### PR TITLE
fix: Animal Kingdom results showing up in App.co

### DIFF
--- a/db/models/app.js
+++ b/db/models/app.js
@@ -203,7 +203,12 @@ module.exports = (sequelize, DataTypes) => {
       const options = _.cloneDeep(App.includeOptions);
       if (!isAdmin) {
         options.attributes = { exclude: App.privateColumns };
-        options.where = { status: 'accepted' };
+        options.where = {
+          status: 'accepted',
+          name: {
+            [Op.notILike]: '%Animal Kingdom%',
+          },
+        };
       }
       return App.findAll(options);
     };


### PR DESCRIPTION
Not sure if this is the best way to filter the query, but this should filter out most the animal kingdom submissions.

See there was an issue https://github.com/blockstack/app.co/issues/386 before relating to this, but results are still showing up on app.co.