### PR TITLE
dont wait to clear cache on admin APIs

### DIFF
--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -54,7 +54,7 @@ router.post('/apps/:appId', async (req, res) => {
   console.log(data);
 
   app = await app.update(data);
-  await clearCache();
+  clearCache();
 
   res.json({ success: true, app });
 });
@@ -218,15 +218,14 @@ router.post('/monthly-reports/:id', async (req, res) => {
       console.error('Error when finding BTC Transaction', data.BTCTransactionId);
     }
   }
-  await clearCache();
+  clearCache();
   res.json({ success: true });
 });
 
 router.delete('/monthly-reports/:monthId/reviewers/:id', async (req, res) => {
   const reviewer = await MiningReviewerReport.findByPk(req.params.id);
   await reviewer.destroy();
-  await clearCache();
-  // console.log(reviewer);
+  clearCache();
   res.json({ success: true });
 });
 


### PR DESCRIPTION
This changes some admin APIs to not wait for the cache to clear before returning JSON. Previously, this was OK, but now the front-end caches warms up before finishing, so this takes quite a while. It adds a bunch of unnecessary friction to some admin UIs.