### PR TITLE
backend changes for dynamic rewards

### DIFF
--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -204,6 +204,8 @@ const updateableReportKeys = [
   'stxPayoutIsIOU',
   'status',
   'name',
+  'btcPayoutTotal',
+  'btcPayoutDecay',
 ];
 
 router.post('/monthly-reports/:id', async (req, res) => {

--- a/db/migrations/20191213023301-add_btc_payout_info.js
+++ b/db/migrations/20191213023301-add_btc_payout_info.js
@@ -1,0 +1,27 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    const opts = { tableName: 'MiningMonthlyReports' };
+    if (process.env.SCHEMA_NAME) {
+      opts.schema = process.env.SCHEMA_NAME;
+    }
+    queryInterface.addColumn(opts, 'btcPayoutTotal', { type: Sequelize.INTEGER, defaultValue: 100000 });
+    queryInterface.addColumn(opts, 'btcPayoutDecay', { type: Sequelize.FLOAT, defaultValue: 0.2 });
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+    */
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.dropTable('users');
+    */
+  },
+};

--- a/server.js
+++ b/server.js
@@ -166,7 +166,7 @@ app.get('/api/app-mining-months', async (req, res) => {
     where: {
       status: 'published',
     },
-    include: MiningMonthlyReport.includeOptions,
+    include: [MiningMonthlyReport.includeOptions[0]],
     order: [['year', 'ASC'], ['month', 'ASC']],
   });
   months = await Promise.map(months, async (report) => {


### PR DESCRIPTION
The current API expects that a single BTC transaction will account for the entirety of App Mining BTC Payments. An admin enters the TX ID, and the API server will map outputs of that TX to apps, based on their BTC address.

This has worked kind of ok, but now we have a new situation, where we made a miscalculation when doing BTC payouts. So, to fix that, we'll have to send another BTC payment out, to make up for the different with some apps.

This means there will no longer be a single transaction of record. Instead, this change allows an admin to specify "top-level" variables like the total payout for BTC, and the "decay rate", which determines how much each app should earn. In fact, this is already how we do it with the recently added STX rewards, and it's a much simpler, cleaner solution.

We kind of need to have this deployed ASAP, because the current month's results page is dependent on this being fixed.